### PR TITLE
Add qt6-wayland-dev dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ RUN apt-get install -y \
     libswscale-dev \
     # Qt 6
     qt6-base-dev \
+    qt6-wayland-dev \
     qt6-base-private-dev \
     libqt6opengl6-dev \
     qt6-multimedia-dev \


### PR DESCRIPTION
Used by Lime3DS/Lime3DS#312 for compiling Lime3DS with wayland support